### PR TITLE
Bug fix 3 mask all but 4 last digits of credit card

### DIFF
--- a/src/main/resources/templates/order_confirmation.html
+++ b/src/main/resources/templates/order_confirmation.html
@@ -37,7 +37,11 @@
                     </div>
                     <div class="summary-info">
                         <h3>Billing Info:</h3>
-                        <span th:text="|Credit Card ${creditCard}|">Credit Card XXXX</span>
+                        <!--/* Bug fix #3: credit card number given to the
+                               model will conceal all but 4 last digits
+                               of credit card number
+                         */-->
+                        <span th:text="|Credit Card ${creditCard}|">Credit Card XXXX1234</span>
                     </div>
                 </div>
                 <div class="mini-cart">

--- a/src/test/java/com/acme/ecommerce/controller/CheckoutControllerTest.java
+++ b/src/test/java/com/acme/ecommerce/controller/CheckoutControllerTest.java
@@ -5,6 +5,7 @@ import com.acme.ecommerce.domain.*;
 import com.acme.ecommerce.service.ProductService;
 import com.acme.ecommerce.service.PurchaseService;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -375,6 +376,21 @@ public class CheckoutControllerTest {
 		mockMvc.perform(MockMvcRequestBuilders.get("/checkout/email")).andDo(print()).andExpect(status().isOk());
 	}
 
+	// test to check whether credit card is hidden
+	@Test
+	public void creditCardNumberShouldBeSuccessfullyHiddenByIntroducedMethod()
+			throws Exception {
+		// When valid credit card number is passed to
+		// makeCreditCardNumberHidden method
+		String creditCardNumber = "1234123412341234";
+		// Then expected hidden credit card number should be returned
+		String hiddenCreditCardNumber =
+				checkoutController.makeCreditCardNumberHidden(creditCardNumber);
+		Assert.assertEquals(
+				"************1234",
+				hiddenCreditCardNumber);
+	}
+
 	private Product productBuilder() {
 		Product product = new Product();
 		product.setId(1L);
@@ -403,4 +419,5 @@ public class CheckoutControllerTest {
         purchase.setCreditCardNumber("1234123412341234");
 		return purchase;
 	}
+
 }

--- a/src/test/java/com/acme/ecommerce/controller/CheckoutControllerTest.java
+++ b/src/test/java/com/acme/ecommerce/controller/CheckoutControllerTest.java
@@ -386,7 +386,10 @@ public class CheckoutControllerTest {
 		product.setThumbImageName("imagename");
 		return product;
 	}
-	
+
+	// Bug fix #3 change: added set of credit card number because,
+	// we need it to be non-null, because of the method converting number
+	// to hidden in controller
 	private Purchase purchaseBuilder(Product product) {
 		ProductPurchase pp = new ProductPurchase();
 		pp.setProductPurchaseId(1L);
@@ -394,10 +397,10 @@ public class CheckoutControllerTest {
 		pp.setProduct(product);
 		List<ProductPurchase> ppList = new ArrayList<ProductPurchase>();
 		ppList.add(pp);
-
 		Purchase purchase = new Purchase();
 		purchase.setId(1L);
 		purchase.setProductPurchases(ppList);
+        purchase.setCreditCardNumber("1234123412341234");
 		return purchase;
 	}
 }


### PR DESCRIPTION
Bug #3 is fixed. Now on the order confirmation page: user's credit card number is hidden except for 4 last digits. This is done in a way, that before sending to the thymeleaf template, user credit card number is converted to hidden using private method introduced in controller. 
