### PR TITLE
Task 7 error view when product not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@
     product quantity that exceeds its amount in stock.
     Include unit tests to verify that flash messages work correctly.
     <hr>
+* [7.] (#task-7)
+    Enhancement:
+    Detect when a product’s detail view is requested,
+    but the id requested isn’t found in the database.
+    The rendered view should display a message saying
+    that the product wasn’t found.
 
 <!--Links-->
 <!-- settings files -->
@@ -375,7 +381,26 @@ Under construction...
        because of the reason above (see description about 'delete' above).
        <hr>
 7. <a id="task-7"></a>
-
+    Enhancement:
+    Detect when a product’s detail view is requested,
+    but the id requested isn’t found in the database.
+    The rendered view should display a message saying
+    that the product wasn’t found.
+    <hr>
+    I changed old code that was redirecting to "error" page in
+    [ProductController] in `productDetail` method. Now when product
+    is null, [NotFoundException] is thrown, and "@ExceptionHandler"
+    method `exceptionHandler` is taking care of this exception,
+    generating [error.html] template in which exception message is
+    printed if exception is not null.
+    <br>
+    Exactly this is tested in [ProductControllerTest] class in
+    `getProductDetailInvalidId` method:
+    - status OK
+    - model has attribute exception of type [NotFoundException]
+    - address is "/error"
+<hr>
+8. <a id="task-8"></a>
 
 
 

--- a/src/main/java/com/acme/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/acme/ecommerce/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.acme.ecommerce.controller;
 
 import com.acme.ecommerce.domain.Product;
 import com.acme.ecommerce.domain.ProductPurchase;
+import com.acme.ecommerce.exception.NotFoundException;
 import com.acme.ecommerce.service.ProductService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -56,7 +58,15 @@ public class ProductController {
 
         return "index";
     }
-    
+
+	// Task #7:
+	// Enhancement:
+	// Detect when a product’s detail view is requested,
+	// but the id requested isn’t found in the database.
+	// The rendered view should display a message saying
+	// that the product wasn’t found.
+	// I throw an NotFoundException, handled in @ExceptionHandler
+	// exceptionHandler method at the bottom
     @RequestMapping(path = "/detail/{id}", method = RequestMethod.GET)
     public String productDetail(@PathVariable long id, Model model) {
     	logger.debug("Details for Product " + id);
@@ -70,7 +80,10 @@ public class ProductController {
     		model.addAttribute("productPurchase", productPurchase);
     	} else {
     		logger.error("Product " + id + " Not Found!");
-    		return "redirect:/error";
+			// new way of handling: NotFoundException
+			throw new NotFoundException("Product Not Found");
+            // old way of handling: simple redirect
+//    		return "redirect:/error";
     	}
 
         return "product_detail";
@@ -105,4 +118,12 @@ public class ProductController {
     	logger.warn("Happy Easter! Someone actually clicked on About.");
     	return("about");
     }
+
+    // Task #7: Here NotFoundException is handled, "error.html" is rendered
+	// and "exception" is added to model.
+    @ExceptionHandler(NotFoundException.class)
+	public String exceptionHandler(Model model, Exception exception){
+    	model.addAttribute("exception", exception);
+		return "/error";
+	}
 }

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -5,11 +5,17 @@
 		<header th:replace="layout :: header('Error')"></header>
 	    <section class="cart">
             <h1>Error</h1>
-            <strong th:if="${errorMessage == null}">
+			<!--/* If there is no exception but simple redirect, we'll
+			       print this simple message
+			*/-->
+            <strong th:if="${exception == null}">
 				This is error page. How to get model attributes here: no idea.
 			</strong>
-			<strong th:if="${errorMessage != null}"
-					th:text="${errorMessage}">
+			<!--/* If there is exception, then we print here exception
+			       message. Usage: Task-6: product not found
+			*/-->
+			<strong th:if="${exception != null}"
+					th:text="${exception.message}">
 				This is error page. How to get model attributes here: no idea.
 			</strong>
 		</section>

--- a/src/test/java/com/acme/ecommerce/controller/ProductControllerTest.java
+++ b/src/test/java/com/acme/ecommerce/controller/ProductControllerTest.java
@@ -2,7 +2,9 @@ package com.acme.ecommerce.controller;
 
 import com.acme.ecommerce.Application;
 import com.acme.ecommerce.domain.Product;
+import com.acme.ecommerce.exception.NotFoundException;
 import com.acme.ecommerce.service.ProductService;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,10 +94,41 @@ public class ProductControllerTest {
 	
 	@Test
 	public void getProductDetailInvalidId() throws Exception {
+	    // Old way of handling error
+//		when(productService.findById(1L)).thenReturn(null);
+//		mockMvc.perform(MockMvcRequestBuilders.get("/product/detail/1"))
+//			.andExpect(status().is3xxRedirection())
+//		    .andExpect(redirectedUrl("/error"));
+
+		// My way of handling error
+
+		// Arrange:
+		// when product service will be called we return null, to throw
+		// exception
 		when(productService.findById(1L)).thenReturn(null);
-		mockMvc.perform(MockMvcRequestBuilders.get("/product/detail/1"))
-			.andExpect(status().is3xxRedirection())
-		    .andExpect(redirectedUrl("/error"));
+
+		// Act and Assert:
+		// When GET request is made to product detail with non-existing
+		// product
+		// Then:
+		// - status should be OK - because error page should be successfully
+		//     generated
+		// - view name has to be "/error"
+		// - model should have attribute exception of type
+		//     NotFoundException
+		mockMvc.perform(
+				MockMvcRequestBuilders
+						.get("/product/detail/1"))
+				.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(view().name("/error"))
+				.andExpect(
+						model().attribute(
+								"exception",
+								Matchers.instanceOf(NotFoundException.class)
+						)
+				);
+
 	}
 
 	@Test


### PR DESCRIPTION
Now when product is not found on detail page, NotFoundException is thrown and handled. Test checks exactly that. This is different way like everything is done in App. But I decided that exception throwing is reasonable.
